### PR TITLE
cancel campaign bug fixes and update

### DIFF
--- a/api/api_main.py
+++ b/api/api_main.py
@@ -4,7 +4,7 @@ from flask_restful_swagger import swagger
 import os
 import logging
 
-from api.campaign import Campaign, CampaignProperties, CampaignDelete
+from api.campaign import Campaign, CampaignProperties, CampaignCancel
 from api.charity import Charities
 from api.stats import Stats
 
@@ -42,8 +42,8 @@ else:
 
 
 # Service to manage stories
-api.add_resource(CampaignDelete, '/campaign/<campaign_id>/<secret_key>',
-                                 '/campaign/<campaign_id>/<secret_key>/')
+api.add_resource(CampaignCancel, '/campaign/<campaign_id>/cancel/<secret_key>',
+                                 '/campaign/<campaign_id>/cancel/<secret_key>/')
 
 api.add_resource(CampaignProperties, '/campaign/<campaign_id>',
                                      '/campaign/<campaign_id>/')
@@ -66,7 +66,7 @@ def root():
 @app.after_request
 def after_request(response):
     response.headers.add('Access-Control-Allow-Headers', 'Content-Type,Authorization')
-    response.headers.add('Access-Control-Allow-Methods', 'GET,POST,DELETE,OPTIONS')
+    response.headers.add('Access-Control-Allow-Methods', 'GET,POST,OPTIONS')
     if is_debug_mode():
         # If in debug mode, allow CORS
         response.headers.add('Access-Control-Allow-Origin', '*')

--- a/api/campaign.py
+++ b/api/campaign.py
@@ -159,19 +159,19 @@ class CampaignProperties(Resource):
 
         return item, 200
 
-    def delete(self, campaign_id):
+    def put(self, campaign_id):
         abort(403, description="Missing Authorization Key")
 
 
-class CampaignDelete(Resource):
+class CampaignCancel(Resource):
 
     def __init__(self):
         super(Resource, self).__init__()
         self.campaign_table = DynamoTable('campaigns')
 
     @swagger.operation(
-        notes='Delete a campaign',
-        nickname='Delete A Campaign',
+        notes='Cancel a campaign',
+        nickname='Cancel A Campaign',
         parameters=[
             {
                 "name": "campaign_id",
@@ -189,8 +189,8 @@ class CampaignDelete(Resource):
                 "dataType": 'string',
                 "paramType": "path"
             }])
-    def delete(self, campaign_id, secret_key):
-        """Delete A Campaign"""
+    def put(self, campaign_id, secret_key):
+        """Cancel A Campaign"""
         # Get the campaign
         data = {"campaign_id": campaign_id}
         item = None

--- a/api/tests/test_api_campaign.py
+++ b/api/tests/test_api_campaign.py
@@ -55,21 +55,19 @@ class APICampaignTestMixin(object):
         assert "campaign_id" in response
 
         # Delete
-        rv = self.app.delete('/campaign/',
+        rv = self.app.put('/campaign/',
                              follow_redirects=True)
         self.assertEqual(rv.status_code, 405)
 
-        rv = self.app.delete('/campaign/{}'.format(response["campaign_id"]),
-                             follow_redirects=True)
+        rv = self.app.put('/campaign/{}'.format(response["campaign_id"]), follow_redirects=True)
         self.assertEqual(rv.status_code, 403)
-        rv = self.app.delete('/campaign/{}/'.format(response["campaign_id"]),
-                             follow_redirects=True)
+        rv = self.app.put('/campaign/{}/'.format(response["campaign_id"]), follow_redirects=True)
         self.assertEqual(rv.status_code, 403)
 
-        rv = self.app.delete('/campaign/{}/{}'.format(response["campaign_id"], "ajkshdfhkjasdf"),
+        rv = self.app.put('/campaign/{}/cancel/{}'.format(response["campaign_id"], "ajkshdfhkjasdf"),
                              follow_redirects=True)
         self.assertEqual(rv.status_code, 403)
-        rv = self.app.delete('/campaign/{}/{}/'.format(response["campaign_id"], "ajkshdfhkjasdf"),
+        rv = self.app.put('/campaign/{}/cancel/{}/'.format(response["campaign_id"], "ajkshdfhkjasdf"),
                              follow_redirects=True)
         self.assertEqual(rv.status_code, 403)
 
@@ -93,7 +91,7 @@ class APICampaignTestMixin(object):
         self.assertEqual(item["campaign_status"], "active")
 
         # Delete
-        rv = self.app.delete('/campaign/{}/{}'.format(response["campaign_id"], item["secret_id"]),
+        rv = self.app.put('/campaign/{}/cancel/{}'.format(response["campaign_id"], item["secret_id"]),
                              follow_redirects=True)
         self.assertEqual(rv.status_code, 204)
 

--- a/frontend/cancel.html
+++ b/frontend/cancel.html
@@ -50,8 +50,8 @@
           $cancelTrigger.text("Cancelling campaign...");
 
           $.ajax({
-            url: rootUrl + "campaign/" + QueryString.id + "/" + QueryString.secret,
-            type: "DELETE",
+            url: rootUrl + "campaign/" + QueryString.id + "/cancel/" + QueryString.secret,
+            type: "PUT",
           }).done(
             function(data) {
               $cancelTrigger.text("Cancelled").attr('disabled', 'disabled');

--- a/zappa_settings.json
+++ b/zappa_settings.json
@@ -3,7 +3,7 @@
     "app_function": "api.api_main.app",
     "aws_region": "us-east-1",
     "project_name": "donatemates-api",
-    "http_methods": ["GET", "POST"],
+    "http_methods": ["GET", "POST", "PUT"],
     "lets_encrypt_key": "account.key",
     "manage_roles": false,
     "environment_variables": {


### PR DESCRIPTION
- Changed cancel campaign to a PUT operation since not actually deleting the resource
- Added missing `http_method` to API Gateway config
- Updated tests
- Updated URL to be /campaign/<campaign_id>/cancel/<secret_key>
- Updated frontend